### PR TITLE
[6주차] Redis 기반 분산락 및 캐싱 전략 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+	implementation("org.springframework.boot:spring-boot-starter-cache")
 	implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
 	// lombok

--- a/src/main/java/kr/hhplus/be/server/application/batch/SeatReservationBatch.java
+++ b/src/main/java/kr/hhplus/be/server/application/batch/SeatReservationBatch.java
@@ -1,8 +1,11 @@
 package kr.hhplus.be.server.application.batch;
 
+import kr.hhplus.be.server.common.exception.ApiException;
+import kr.hhplus.be.server.common.exception.ErrorCode;
 import kr.hhplus.be.server.domain.concert.Seat;
 import kr.hhplus.be.server.domain.concert.SeatRepository;
 import kr.hhplus.be.server.domain.concert.SeatStatus;
+import kr.hhplus.be.server.domain.lock.DistributedLockRepository;
 import kr.hhplus.be.server.domain.queue.QueueTokenRepository;
 import kr.hhplus.be.server.domain.reservation.ReservationStatus;
 import kr.hhplus.be.server.domain.reservation.SeatReservation;
@@ -14,8 +17,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.function.Supplier;
 
 @Component
 @RequiredArgsConstructor
@@ -25,39 +28,109 @@ public class SeatReservationBatch {
     private final SeatReservationRepository seatReservationRepository;
     private final SeatRepository seatRepository;
     private final QueueTokenRepository queueTokenRepository;
+    private final DistributedLockRepository distributedLockRepository;
+
+    private static final long LOCK_TIMEOUT_MILLIS = 15000;
+    private static final int MAX_RETRY = 10;
+    private static final long SLEEP_MILLIS = 200;
+
 
     @Scheduled(fixedDelay = 100_000)
-    @Transactional
     public void expireTempReservations() {
         LocalDateTime now = LocalDateTime.now();
         // 임시예약 상태(TEMP_RESERVED)면서 만료시각이 현재보다 지난 예약 찾기
-        List<SeatReservation> expiredReservations =
-                seatReservationRepository.findByStatusAndExpiredAtBefore(ReservationStatus.TEMP_RESERVED, now);
+        List<SeatReservation> expiredReservations = seatReservationRepository.findByStatusAndExpiredAtBefore(ReservationStatus.TEMP_RESERVED, now);
 
         for (SeatReservation reservation : expiredReservations) {
-            expireReservationAndSeat(reservation);
+
+            // 락 획득
+            List<String> lockKeys = Arrays.asList(
+                    "reservation-lock:" + reservation.getReservationId(),
+                    "seat-lock:" + reservation.getSeatId()
+            );
+
+            withMultiLock(lockKeys, () -> {
+                expireReservationAndSeatTransactional(reservation.getReservationId(), reservation.getSeatId());
+                return null;
+            });
         }
     }
 
+    /**
+     * # Method설명 : 여러 분산락 순차적으로 획득
+     * # MethodName : withMultiLock
+     **/
+    private <T> T withMultiLock(List<String> lockKeys, Supplier<T> action) {
+        List<String> acquiredKeys = new ArrayList<>();  // 획득한 락 key 리스트
+        List<String> lockValues = new ArrayList<>();    // 각 락의 고유 value (락 해제시 사용)
+        try {
+            // 각 key 별로 순서대로 락 획득 시도
+            for (String lockKey : lockKeys) {
+                String lockValue = UUID.randomUUID().toString();
+                boolean locked = false;
+                int tryCount = 0;
+                // 스핀락 방식으로 최대 MAX_RETRY번 재시도
+                while (!locked && tryCount < MAX_RETRY) {
+                    locked = distributedLockRepository.tryLock(lockKey, lockValue, LOCK_TIMEOUT_MILLIS);
+                    if (!locked) {  // 락 획득 실패
+                        tryCount++;
+                        Thread.sleep(SLEEP_MILLIS);
+                    }
+                }
+                if (!locked) {  // 최종적으로 락 획득 실패
+                    releaseAllLocks(acquiredKeys, lockValues);  // 획득한 락 전체 해제
+                    log.warn("락 획득 실패: {}", lockKey);
+                    return null;
+                }
+                // 3. 획득한 락 리스트에 추가
+                acquiredKeys.add(lockKey);
+                lockValues.add(lockValue);
+            }
+            return action.get();    // 모든 락 획득 후 비즈니스 로직 실행
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            releaseAllLocks(acquiredKeys, lockValues);
+            log.error("락 획득 중 인터럽트 발생");
+            return null;
+        } catch (RuntimeException e) {
+            releaseAllLocks(acquiredKeys, lockValues);
+            throw e;
+        } finally {
+            releaseAllLocks(acquiredKeys, lockValues);
+        }
+    }
+
+    /**
+     * # Method설명 : 락 전체 해제
+     * # MethodName : releaseAllLocks
+     **/
+    private void releaseAllLocks(List<String> lockKeys, List<String> lockValues) {
+        for (int i = 0; i < lockKeys.size(); i++) {
+            try {
+                distributedLockRepository.unlock(lockKeys.get(i), lockValues.get(i));
+            } catch (Exception ignore) {}
+        }
+    }
+
+
     @Transactional
-    public void expireReservationAndSeat(SeatReservation reservation) {
+    public void expireReservationAndSeatTransactional(Long reservationId, Long seatId) {
 
-        // 1. 비관적 락으로 예약 엔티티 다시 조회
-        Optional<SeatReservation> lockedReservationOpt = seatReservationRepository.findByIdForUpdate(reservation.getReservationId());
-        if(lockedReservationOpt.isEmpty()){
-            log.warn("예약 정보 없음: {}", reservation.getReservationId());
+        // 1. 예약 조회
+        Optional<SeatReservation> reservationOpt = seatReservationRepository.findById(reservationId);
+        if (reservationOpt.isEmpty()) {
+            log.warn("예약 정보 없음: {}", reservationId);
+            return;
+        }
+        SeatReservation reservation = reservationOpt.get();
+        if (reservation.getStatus() != ReservationStatus.TEMP_RESERVED) {   // 임시 예약 확인
             return;
         }
 
-        SeatReservation lockedReservation = lockedReservationOpt.get();
-        if (lockedReservation.getStatus() != ReservationStatus.TEMP_RESERVED) {
-            return;
-        }
-
-        // 2. 좌석에 비관적 락 걸어서 select (seatId 사용)
-        Optional<Seat> seatOpt = seatRepository.findBySeatIdForUpdate(reservation.getSeatId());
+        // 2. 좌석 조회
+        Optional<Seat> seatOpt = seatRepository.findById(seatId);
         if (seatOpt.isEmpty()) {
-            log.warn("좌석 없음: {}", reservation.getSeatId());
+            log.warn("좌석 정보 없음: {}", seatId);
             return;
         }
         Seat seat = seatOpt.get();

--- a/src/main/java/kr/hhplus/be/server/application/payment/PaymentService.java
+++ b/src/main/java/kr/hhplus/be/server/application/payment/PaymentService.java
@@ -63,24 +63,20 @@ public class PaymentService {   // 좌석 예약 서비스
     // 트랜잭션 내 결제 처리
     @Transactional
     protected Payment paymentTransactional(Long userId, Long reservationId, Long seatId) {
-//        try {
-            // 1. 검증 및 데이터 조회
-            SeatReservation seatReservation = validateSeatReservation(reservationId, userId);
-            Seat seat = validateSeat(seatId);
-            int amount = seat.getPrice();
+        // 1. 검증 및 데이터 조회
+        SeatReservation seatReservation = validateSeatReservation(reservationId, userId);
+        Seat seat = validateSeat(seatId);
+        int amount = seat.getPrice();
 
-            // 2. 비즈니스 처리
-            useBalance(userId, amount);     // 잔액 차감
-            Payment payment = savePayment(userId, seatReservation.getReservationId(), amount); // 결제 생성
-            confirmReservation(seatReservation); // 예약 확정
-            confirmSeat(seat);                  // 좌석 확정
+        // 2. 비즈니스 처리
+        useBalance(userId, amount);     // 잔액 차감
+        Payment payment = savePayment(userId, seatReservation.getReservationId(), amount); // 결제 생성
+        confirmReservation(seatReservation); // 예약 확정
+        confirmSeat(seat);                  // 좌석 확정
 
-            // 3. 후처리
-            expireQueueToken(userId, seat.getScheduleId());  // 토큰 만료
-            return payment;
-//        } catch (DataIntegrityViolationException e) {
-//            throw new ApiException(ErrorCode.INVALID_INPUT_VALUE, String.format("해당 예약(%d)은 이미 결제되었거나 결제가 불가능한 상태입니다.", reservationId));
-//        }
+        // 3. 후처리
+        expireQueueToken(userId, seat.getScheduleId());  // 토큰 만료
+        return payment;
     }
 
 

--- a/src/main/java/kr/hhplus/be/server/application/reservation/ReserveSeatService.java
+++ b/src/main/java/kr/hhplus/be/server/application/reservation/ReserveSeatService.java
@@ -11,6 +11,7 @@ import kr.hhplus.be.server.domain.reservation.SeatReservationRepository;
 import kr.hhplus.be.server.domain.user.User;
 import kr.hhplus.be.server.domain.user.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +19,7 @@ import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class ReserveSeatService {   // 좌석 예약 서비스
@@ -31,7 +33,7 @@ public class ReserveSeatService {   // 좌석 예약 서비스
 
     // 임시예약 만료 시간
     private static final int RESERVATION_TIMEOUT_MINUTES = 5;
-    private static final long SEAT_LOCK_TIMEOUT_MILLIS = 15000;
+    private static final long SEAT_LOCK_TIMEOUT_MILLIS = 30000;
 
     /**
      * # Method설명 : 좌석 예약
@@ -42,22 +44,37 @@ public class ReserveSeatService {   // 좌석 예약 서비스
         // 검증 단계
         User user = validateUser(userId);   // 사용자
         ConcertSchedule schedule = validateSchedule(concertDate);   // 일정
-        Seat seat = validateSeat(schedule.getScheduleId(), seatNumber); // 좌석
         validateQueueToken(userId, schedule.getScheduleId());   // 토큰
+        Long seatId = seatRepository.findSeatIdByScheduleIdAndSeatNumber(schedule.getScheduleId(), seatNumber);
 
         // 분산 락
-        String lockKey = "seat-lock:" + seat.getSeatId();
+        String lockKey = "seat-lock:" + seatId;   // 좌석 id로 락
         String lockValue = UUID.randomUUID().toString();
-        if (!distributedLockRepository.tryLock(lockKey, lockValue, SEAT_LOCK_TIMEOUT_MILLIS)) {
-            throw new ApiException(ErrorCode.FORBIDDEN, "동일 좌석("+seatNumber+")에 대한 예약이 이미 진행 중입니다. 잠시 후 다시 시도해주세요.");
-        }
 
-        try {
-            // 3. 좌석 임시예약 처리 (트랜잭션)
-            return reserveSeatTransactional(user.getUserId(), seatNumber, seat);
-        } finally {
-            // 4. 락 해제
-            distributedLockRepository.unlock(lockKey, lockValue);
+        final int MAX_RETRY = 10;   // 최대 시도 수
+        final long SLEEP_MILLIS = 200;  // 대기 시간
+        int tryCount = 0;   // 시도 수
+
+        while (true) {
+            boolean locked = distributedLockRepository.tryLock(lockKey, lockValue, SEAT_LOCK_TIMEOUT_MILLIS);
+            if (locked) {   // 락 획득 성공
+                try {
+                    return reserveSeatTransactional(user.getUserId(), seatId, seatNumber);    // 좌석 임시 예약 처리
+                } finally {
+                    distributedLockRepository.unlock(lockKey, lockValue);   // 락 해제
+                }
+            } else {        // 락 획득 실패
+                tryCount++;
+                if (tryCount >= MAX_RETRY) {
+                    throw new ApiException(ErrorCode.FORBIDDEN, "동일 좌석(" + seatNumber + ")에 대한 예약이 이미 진행 중입니다. 잠시 후 다시 시도해주세요.");
+                }
+                try {
+                    Thread.sleep(SLEEP_MILLIS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR, "락 대기 중 인터럽트 발생");
+                }
+            }
         }
     }
 
@@ -68,7 +85,7 @@ public class ReserveSeatService {   // 좌석 예약 서비스
      **/
     private User validateUser(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() -> new ApiException(ErrorCode.RESOURCE_NOT_FOUND, "해당 ID("+ userId +")의 사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new ApiException(ErrorCode.RESOURCE_NOT_FOUND, "해당 ID(" + userId + ")의 사용자를 찾을 수 없습니다."));
     }
 
     /**
@@ -77,9 +94,9 @@ public class ReserveSeatService {   // 좌석 예약 서비스
      **/
     private ConcertSchedule validateSchedule(LocalDate concertDate) {
         ConcertSchedule schedule = scheduleRepository.findByConcertDate(concertDate)
-                .orElseThrow(() -> new ApiException(ErrorCode.RESOURCE_NOT_FOUND, "선택한 날짜("+ concertDate +")에 해당하는 콘서트가 존재하지 않습니다."));
+                .orElseThrow(() -> new ApiException(ErrorCode.RESOURCE_NOT_FOUND, "선택한 날짜(" + concertDate + ")에 해당하는 콘서트가 존재하지 않습니다."));
         if (schedule.getConcertDate().isBefore(LocalDate.now())) {  // 이미 지난 날짜
-            throw new ApiException(ErrorCode.INVALID_INPUT_VALUE, "선택한 날짜("+concertDate+")에 해당하는 콘서트는 예약할 수 없습니다.");
+            throw new ApiException(ErrorCode.INVALID_INPUT_VALUE, "선택한 날짜(" + concertDate + ")에 해당하는 콘서트는 예약할 수 없습니다.");
         }
         return schedule;
     }
@@ -91,7 +108,7 @@ public class ReserveSeatService {   // 좌석 예약 서비스
     private QueueToken validateQueueToken(Long userId, Long scheduleId) {
         Optional<String> tokenIdOpt = queueTokenRepository.findTokenIdByUserIdAndScheduleId(userId, scheduleId);    // userId, scheduleId로 토큰 조회
         if (tokenIdOpt.isEmpty()) {
-            throw new ApiException(ErrorCode.INVALID_INPUT_VALUE, "사용자 ID("+userId+")로 발급된 대기열 토큰이 존재하지 않습니다.");
+            throw new ApiException(ErrorCode.INVALID_INPUT_VALUE, "사용자 ID(" + userId + ")로 발급된 대기열 토큰이 존재하지 않습니다.");
         }
 
         QueueToken queueToken = queueTokenRepository.findQueueTokenByTokenId(tokenIdOpt.get()).orElseThrow(() -> new ApiException(ErrorCode.INVALID_INPUT_VALUE, "유효하지 않은 대기열 토큰입니다. " + tokenIdOpt.get()));
@@ -101,22 +118,17 @@ public class ReserveSeatService {   // 좌석 예약 서비스
         return queueToken;
     }
 
-    /**
-     * # Method설명 : 좌석 검증
-     * # MethodName : validateSeat
-     **/
-    private Seat validateSeat(Long scheduleId, int seatNumber){
-        return seatRepository.findByConcertSchedule_ScheduleIdAndSeatNumber(scheduleId, seatNumber)
-                .orElseThrow(() -> new ApiException(ErrorCode.RESOURCE_NOT_FOUND, "선택한 좌석("+ seatNumber +")은 존재하지 않습니다."));
-    }
-
 
     /**
      * # Method설명 : 예약 트랜잭션
      * # MethodName : reserveSeatTransactional
      **/
     @Transactional
-    public SeatReservation reserveSeatTransactional(Long userId, int seatNumber, Seat seat) {
+    public SeatReservation reserveSeatTransactional(Long userId, Long seatId, int seatNumber) {
+
+        // 락 획득 후 다시 좌석 조회 (락 획득 전에 조회한 좌석은 예약 완료된 상태가 적용되지 않음)
+        Seat seat = seatRepository.findById(seatId)
+                .orElseThrow(() -> new ApiException(ErrorCode.RESOURCE_NOT_FOUND, "선택한 좌석(" + seatNumber + ")은 존재하지 않습니다."));
 
         // 만료된 임시예약 해제 (좌석 상태 갱신)
         if (seat.getStatus() == SeatStatus.TEMP_RESERVED && seat.isExpired(RESERVATION_TIMEOUT_MINUTES)) {
@@ -126,7 +138,7 @@ public class ReserveSeatService {   // 좌석 예약 서비스
 
         // 예약 불가능한 상태라면 예외
         if (!seat.isAvailable(RESERVATION_TIMEOUT_MINUTES)) {
-            throw new ApiException(ErrorCode.INVALID_INPUT_VALUE, "선택한 좌석("+ seatNumber +")은 이미 예약된 좌석입니다.");
+            throw new ApiException(ErrorCode.INVALID_INPUT_VALUE, "선택한 좌석(" + seatNumber + ")은 이미 예약된 좌석입니다.");
         }
 
         // 임시 예약 처리

--- a/src/main/java/kr/hhplus/be/server/application/reservation/ReserveSeatService.java
+++ b/src/main/java/kr/hhplus/be/server/application/reservation/ReserveSeatService.java
@@ -33,7 +33,9 @@ public class ReserveSeatService {   // 좌석 예약 서비스
 
     // 임시예약 만료 시간
     private static final int RESERVATION_TIMEOUT_MINUTES = 5;
-    private static final long SEAT_LOCK_TIMEOUT_MILLIS = 30000;
+    private static final long LOCK_TIMEOUT_MILLIS = 15000; // 락 지속 시간
+    private static int MAX_RETRY = 10;   // 최대 시도 수
+    private static long SLEEP_MILLIS = 200;  // 대기 시간
 
     /**
      * # Method설명 : 좌석 예약
@@ -51,12 +53,10 @@ public class ReserveSeatService {   // 좌석 예약 서비스
         String lockKey = "seat-lock:" + seatId;   // 좌석 id로 락
         String lockValue = UUID.randomUUID().toString();
 
-        final int MAX_RETRY = 10;   // 최대 시도 수
-        final long SLEEP_MILLIS = 200;  // 대기 시간
         int tryCount = 0;   // 시도 수
 
         while (true) {
-            boolean locked = distributedLockRepository.tryLock(lockKey, lockValue, SEAT_LOCK_TIMEOUT_MILLIS);
+            boolean locked = distributedLockRepository.tryLock(lockKey, lockValue, LOCK_TIMEOUT_MILLIS);
             if (locked) {   // 락 획득 성공
                 try {
                     return reserveSeatTransactional(user.getUserId(), seatId, seatNumber);    // 좌석 임시 예약 처리

--- a/src/main/java/kr/hhplus/be/server/application/user/UserService.java
+++ b/src/main/java/kr/hhplus/be/server/application/user/UserService.java
@@ -3,6 +3,7 @@ package kr.hhplus.be.server.application.user;
 
 import kr.hhplus.be.server.common.exception.ApiException;
 import kr.hhplus.be.server.common.exception.ErrorCode;
+import kr.hhplus.be.server.domain.lock.DistributedLockRepository;
 import kr.hhplus.be.server.domain.user.User;
 import kr.hhplus.be.server.domain.user.UserBalance;
 import kr.hhplus.be.server.domain.user.UserBalanceRepository;
@@ -11,20 +12,28 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+import java.util.function.Supplier;
+
 @RequiredArgsConstructor
 @Service
 public class UserService {   // 좌석 예약 서비스
     private final UserRepository userRepository;
 
     private final UserBalanceRepository userBalanceRepository;
+    private final DistributedLockRepository distributedLockRepository;
+
+    private static final long LOCK_TIMEOUT_MILLIS = 15000;
+    private static int MAX_RETRY = 10;   // 최대 시도 수
+    private static long SLEEP_MILLIS = 200;  // 대기 시간
+
 
     /**
      * # Method설명 : 사용자 조회
      * # MethodName : getUser
      **/
     public User getUser(Long userId) {
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new ApiException(ErrorCode.RESOURCE_NOT_FOUND, "해당 ID("+ userId +")의 사용자를 찾을 수 없습니다."));
+        return validateUser(userId);
     }
 
     /**
@@ -33,9 +42,7 @@ public class UserService {   // 좌석 예약 서비스
      **/
     public UserBalance getCurrentBalance(Long userId) {
 
-        // 사용자 검증
-        userRepository.findById(userId)
-                .orElseThrow(() -> new ApiException(ErrorCode.RESOURCE_NOT_FOUND, "해당 ID("+ userId +")의 사용자를 찾을 수 없습니다."));
+        validateUser(userId);   // 사용자 검증
 
         // 잔액 조회
         return userBalanceRepository.findTopByUser_UserIdOrderByBalanceHistoryIdDesc(userId)
@@ -43,57 +50,89 @@ public class UserService {   // 좌석 예약 서비스
     }
 
     /**
-     * # Method설명 : 사용자 잔액 충전 (요청 DTO: userId, amount, type)
+     * # Method설명 : 사용자 잔액 충전
      * # MethodName : chargeBalance
      **/
-    @Transactional
     public UserBalance chargeBalance(Long userId, long amount) {
-
-        // 사용자 검증
-        userRepository.findById(userId)
-                .orElseThrow(() -> new ApiException(ErrorCode.RESOURCE_NOT_FOUND, "해당 ID("+ userId +")의 사용자를 찾을 수 없습니다."));
-
-        // 현재 잔액 조회 (없으면 0)
-        long currentBalance = userBalanceRepository
-                .findTopByUser_UserIdOrderByBalanceHistoryIdDescForUpdate(userId)
-                .map(UserBalance::getCurrentBalance)
-                .orElse(0L);
-
-        // 잔액 충전
-        UserBalance chargedBalance = UserBalance.charge(
-                userId,
-                amount,
-                currentBalance
-        );
-
-        return userBalanceRepository.save(chargedBalance);
+        validateUser(userId);
+        return withUserBalanceLock(userId, () -> chargeBalanceTransactional(userId, amount));
     }
 
     /**
      * # Method설명 : 사용자 잔액 사용
      * # MethodName : useBalance
      **/
-    @Transactional
     public UserBalance useBalance(Long userId, long amount) {
+        validateUser(userId);
+        return withUserBalanceLock(userId, () -> useBalanceTransactional(userId, amount));
+    }
 
-        // 사용자 검증
-        userRepository.findById(userId)
-                .orElseThrow(() -> new ApiException(ErrorCode.RESOURCE_NOT_FOUND, "해당 ID("+ userId +")의 사용자를 찾을 수 없습니다."));
+    /**
+     * # Method설명 : 사용자 잔액 분산락
+     * # MethodName : withUserBalanceLock
+     **/
+    private UserBalance withUserBalanceLock(Long userId, Supplier<UserBalance> action) {
+        String lockKey = "userBalance-lock:" + userId;  // 사용자 id로 사용자 잔액 락
+        String lockValue = UUID.randomUUID().toString();
+        int tryCount = 0;
 
+        while (true) {
+            boolean locked = distributedLockRepository.tryLock(lockKey, lockValue, LOCK_TIMEOUT_MILLIS);
+            if (locked) {   // 락 획득
+                try {
+                    return action.get();    // 트랜잭션 부분 실행
+                } finally {
+                    distributedLockRepository.unlock(lockKey, lockValue);   // 락 해제
+                }
+            } else {        // 락 획득 실패
+                tryCount++;
+                if (tryCount >= MAX_RETRY) {
+                    throw new ApiException(ErrorCode.FORBIDDEN, "요청이 많아 처리가 지연되고 있습니다. 잠시 후 다시 시도해 주세요.");
+                }
+                try {
+                    Thread.sleep(SLEEP_MILLIS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR, "락 대기 중 인터럽트 발생");
+                }
+            }
+        }
+    }
 
-        // 현재 잔액 조회 (없으면 0)
-        long currentBalance = userBalanceRepository
-                .findTopByUser_UserIdOrderByBalanceHistoryIdDescForUpdate(userId)
-                .map(UserBalance::getCurrentBalance)
-                .orElse(0L);
+    /**
+     * # Method설명 : 사용자 userId 검증
+     * # MethodName : validateUser
+     **/
+    private User validateUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.RESOURCE_NOT_FOUND, "해당 ID(" + userId + ")의 사용자를 찾을 수 없습니다."));
+    }
+
+    /**
+     * # Method설명 : 사용자 잔액 충전 트랜잭션
+     * # MethodName : chargeBalanceTransactional
+     **/
+    @Transactional
+    protected UserBalance chargeBalanceTransactional(Long userId, long amount){
+        // 현재 잔액 조회
+        long currentBalance = userBalanceRepository.findCurrentBalanceByUserId(userId);
+
+        // 잔액 충전
+        UserBalance chargedBalance = UserBalance.charge(userId, amount, currentBalance);
+        return userBalanceRepository.save(chargedBalance);
+    }
+
+    /**
+     * # Method설명 : 사용자 잔액 사용 트랜잭션
+     * # MethodName : useBalanceTransactional
+     **/
+    @Transactional
+    protected UserBalance useBalanceTransactional(Long userId, long amount){
+        // 현재 잔액 조회
+        long currentBalance = userBalanceRepository.findCurrentBalanceByUserId(userId);
 
         // 잔액 사용
-        UserBalance usedBalance = UserBalance.use(
-                userId,
-                amount,
-                currentBalance
-        );
-
+        UserBalance usedBalance = UserBalance.use(userId, amount, currentBalance);
         return userBalanceRepository.save(usedBalance);
     }
 

--- a/src/main/java/kr/hhplus/be/server/domain/concert/SeatRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/concert/SeatRepository.java
@@ -11,9 +11,14 @@ public interface SeatRepository {
     // 일정ID, 좌석번호, 상태로 조회
     Optional<Seat> findByConcertSchedule_ScheduleIdAndSeatNumberAndStatus(Long scheduleId, int seatNumber, SeatStatus status);
 
+    // 일정ID, 좌석 번호로 좌석 ID만 조회
+    Long findSeatIdByScheduleIdAndSeatNumber(Long scheduleId, int seatNumber);
+
+    // 일정ID, 좌석 번호로 Seat 조회
     Optional<Seat> findByConcertSchedule_ScheduleIdAndSeatNumber(Long scheduleId, int seatNumber);
 
     Optional<Seat> findByConcertSchedule_ScheduleIdAndSeatNumberForUpdate(Long scheduleId, int seatNumber);
+
     Optional<Seat> findBySeatIdForUpdate(Long seatId);
 
     Seat save(Seat payment);

--- a/src/main/java/kr/hhplus/be/server/domain/lock/DistributedLockRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/lock/DistributedLockRepository.java
@@ -1,6 +1,10 @@
 package kr.hhplus.be.server.domain.lock;
 
+import java.util.List;
+import java.util.function.Supplier;
+
 public interface DistributedLockRepository {
     boolean tryLock(String key, String value, long timeoutMillis);
     void unlock(String key, String value);
+    <T> T withMultiLock(List<String> lockKeys, Supplier<T> action, long timeoutMillis, int maxRetry, long sleepMillis);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/reservation/SeatReservation.java
+++ b/src/main/java/kr/hhplus/be/server/domain/reservation/SeatReservation.java
@@ -79,9 +79,13 @@ public class  SeatReservation {
         }
     }
 
+    /**
+     * # Method설명 : 결제 가능 상태 검증
+     * # MethodName : validateAvailableToPay
+     **/
     public void validateAvailableToPay() {
-        if (this.status != ReservationStatus.TEMP_RESERVED || this.expiredAt.isBefore(LocalDateTime.now())) {
-            throw new ApiException(ErrorCode.INVALID_INPUT_VALUE, String.format("결제할 수 없는 예약 정보(%d)입니다.", this.reservationId));
+        if (this.status != ReservationStatus.TEMP_RESERVED || (this.expiredAt != null && this.expiredAt.isBefore(LocalDateTime.now()))) {
+            throw new ApiException(ErrorCode.INVALID_INPUT_VALUE, String.format("해당 예약(%d)은 이미 결제되었거나 결제가 불가능한 상태입니다.", this.reservationId));
         }
     }
 

--- a/src/main/java/kr/hhplus/be/server/domain/reservation/SeatReservationRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/reservation/SeatReservationRepository.java
@@ -10,5 +10,6 @@ public interface SeatReservationRepository {
     Optional<SeatReservation> findByIdForUpdate(Long reservationId);    // lock
     Optional<SeatReservation> findByReservationIdAndUser_UserId(Long reservationId, Long userId);
     List<SeatReservation> findByStatusAndExpiredAtBefore(ReservationStatus status, LocalDateTime expiredAt);
+    Long findSeatIdById(Long reservationId);
     void deleteAllForTest();
 }

--- a/src/main/java/kr/hhplus/be/server/domain/user/UserBalanceRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/user/UserBalanceRepository.java
@@ -10,9 +10,23 @@ public interface UserBalanceRepository {
      **/
     Optional<UserBalance> findTopByUser_UserIdOrderByBalanceHistoryIdDesc(Long userId);
 
+    /**
+     * # Method설명 : userId로 최근 잔액내역 1권 조회 (비관적 락 적용)
+     * # MethodName : findTopByUser_UserIdOrderByBalanceHistoryIdDescForUpdate
+     **/
+    Optional<UserBalance> findTopByUser_UserIdOrderByBalanceHistoryIdDescForUpdate(Long userId);
+
+    /**
+     * # Method설명 : 사용자 현재 잔액 조회
+     * # MethodName : findCurrentBalanceByUserId
+     **/
+    Long findCurrentBalanceByUserId(Long userId);
+
+    /**
+     * # Method설명 : 잔액내역 저장
+     * # MethodName : save
+     **/
     UserBalance save(UserBalance userBalance);
 
     void deleteAllForTest();
-
-    Optional<UserBalance> findTopByUser_UserIdOrderByBalanceHistoryIdDescForUpdate(Long userId);
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/configuration/RedisCacheConfig.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/configuration/RedisCacheConfig.java
@@ -1,0 +1,34 @@
+package kr.hhplus.be.server.infrastructure.configuration;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableCaching
+@EnableConfigurationProperties(RedisCacheProperties.class)
+public class RedisCacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory cf, RedisCacheProperties redisCacheProperties) {
+        // 각 캐시별로 TTL 설정
+        Map<String, RedisCacheConfiguration> cacheConfigs = new HashMap<>();
+        redisCacheProperties.getConfigs().forEach((cacheName, detail) -> {
+            RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMillis(detail.getTtl()));
+            cacheConfigs.put(cacheName, config);
+        });
+
+        // 기본 TTL 설정 (30분)
+        return RedisCacheManager.builder(cf).cacheDefaults(RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(1800000))).withInitialCacheConfigurations(cacheConfigs).build();
+    }
+
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/configuration/RedisCacheProperties.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/configuration/RedisCacheProperties.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.infrastructure.configuration;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "spring.cache.redis")
+public class RedisCacheProperties {
+    private Map<String, CacheDetail> configs;
+
+    @Getter
+    @Setter
+    public static class CacheDetail {
+        private long ttl;
+        private long maxIdleTime;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/persistence/concert/SeatJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/persistence/concert/SeatJpaRepository.java
@@ -34,6 +34,11 @@ public class SeatJpaRepository implements SeatRepository {
     }
 
     @Override
+    public Long findSeatIdByScheduleIdAndSeatNumber(Long scheduleId, int seatNumber) {
+        return seatRepository.findSeatIdByScheduleIdAndSeatNumber(scheduleId,seatNumber).orElse(null);
+    }
+
+    @Override
     public Optional<Seat> findByConcertSchedule_ScheduleIdAndSeatNumber(Long scheduleId, int seatNumber) {
         return seatRepository.findByConcertSchedule_ScheduleIdAndSeatNumber(scheduleId, seatNumber).map(this::toDomain);
     }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/persistence/concert/SpringDataSeatJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/persistence/concert/SpringDataSeatJpaRepository.java
@@ -18,6 +18,10 @@ public interface SpringDataSeatJpaRepository extends JpaRepository<SeatEntity, L
     // 일정ID, 좌석번호, 상태로 조회
     Optional<SeatEntity> findByConcertSchedule_ScheduleIdAndSeatNumberAndStatus(Long scheduleId, int seatNumber, SeatStatus status);
 
+    // 일정ID, 좌석번호로 좌석ID만 조회
+    @Query("select s.seatId from SeatEntity s where s.concertSchedule.scheduleId = :scheduleId and s.seatNumber = :seatNumber")
+    Optional<Long> findSeatIdByScheduleIdAndSeatNumber(@Param("scheduleId") Long scheduleId, @Param("seatNumber") int seatNumber);
+
     // 일정ID, 좌석번호로 조회
     Optional<SeatEntity> findByConcertSchedule_ScheduleIdAndSeatNumber(Long scheduleId, int seatNumber);
 

--- a/src/main/java/kr/hhplus/be/server/infrastructure/persistence/lock/RedisDistributedLockRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/persistence/lock/RedisDistributedLockRepository.java
@@ -1,13 +1,19 @@
 package kr.hhplus.be.server.infrastructure.persistence.lock;
 
+import kr.hhplus.be.server.common.exception.ApiException;
+import kr.hhplus.be.server.common.exception.ErrorCode;
 import kr.hhplus.be.server.domain.lock.DistributedLockRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 @Repository
 @RequiredArgsConstructor
@@ -32,5 +38,64 @@ public class RedisDistributedLockRepository implements DistributedLockRepository
         script.setScriptText(UNLOCK_SCRIPT);
         script.setResultType(Long.class);
         redisTemplate.execute(script, Collections.singletonList(key), value);
+    }
+
+    /**
+     * # Method설명 : 분산락 순차적으로 획득
+     * # MethodName : withMultiLock
+     **/
+    @Override
+    public <T> T withMultiLock(List<String> lockKeys, Supplier<T> action, long timeoutMillis, int maxRetry, long sleepMillis) {
+        List<String> acquiredKeys = new ArrayList<>();  // 획득한 락 key 리스트
+        List<String> lockValues = new ArrayList<>();    // 각 락의 고유 value (락 해제시 사용)
+
+        Collections.sort(lockKeys); // 항상 같은 순서로 락 획득 (사전순 정렬)
+
+        try {
+            // 각 key 별로 순서대로 락 획득 시도
+            for (String lockKey : lockKeys) {
+                String lockValue = UUID.randomUUID().toString();
+                boolean locked = false;
+                int tryCount = 0;
+
+                // 스핀락 방식으로 최대 maxRetry번 재시도
+                while (!locked && tryCount < maxRetry) {
+                    locked = tryLock(lockKey, lockValue, timeoutMillis);
+                    if (!locked) {
+                        tryCount++;
+                        Thread.sleep(sleepMillis);
+                    }
+                }
+                if (!locked) {  // 최종적으로 락 획득 실패
+                    releaseAllLocks(acquiredKeys, lockValues);  // 획득한 락 전체 해제
+                    throw new ApiException(ErrorCode.FORBIDDEN, "요청이 많아 처리가 지연되고 있습니다. 잠시 후 다시 시도해 주세요.");
+                }
+                // 3. 획득한 락 리스트에 추가
+                acquiredKeys.add(lockKey);
+                lockValues.add(lockValue);
+            }
+            return action.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            releaseAllLocks(acquiredKeys, lockValues);
+            throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR, "락 획득 중 인터럽트 발생");
+        } catch (RuntimeException e) {
+            releaseAllLocks(acquiredKeys, lockValues);
+            throw e;
+        } finally {
+            releaseAllLocks(acquiredKeys, lockValues);
+        }
+    }
+
+    /**
+     * # Method설명 : 락 전체 해제
+     * # MethodName : releaseAllLocks
+     **/
+    private void releaseAllLocks(List<String> lockKeys, List<String> lockValues) {
+        for (int i = 0; i < lockKeys.size(); i++) {
+            try {
+                unlock(lockKeys.get(i), lockValues.get(i));
+            } catch (Exception ignore) {}
+        }
     }
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/persistence/queue/RedisQueueTokenRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/persistence/queue/RedisQueueTokenRepository.java
@@ -22,21 +22,34 @@ public class RedisQueueTokenRepository implements QueueTokenRepository {
 
     private final RedisTemplate<String, Object> redisTemplate;
 
-    // Redis Key 생성
-
-    // 토큰 정보 전체를 저장할 때 쓰는 키(이름)
+    /**
+     * # Method설명 : 대기열 토큰(token)으로 Key 생성
+     * # MethodName : tokenInfoKey
+     **/
     private String tokenInfoKey(String token) {
         return "queue:token:" + token;
     }
-    // userId와 scheduleId 조합으로 토큰ID를 저장/찾을 때 쓰는 키(이름)
+
+    /**
+     * # Method설명 : userId와 scheduleId 조합으로 key 생성
+     * # MethodName : userScheduleKey
+     **/
     private String userScheduleKey(Long userId, Long scheduleId) {
         return "queue:user-schedule:" + userId + ":" + scheduleId;
     }
-    // 콘서트별 ACTIVE(입장가능) ZSet의 key
+
+    /**
+     * # Method설명 : 일정ID로 ACTIVE(입장가능) key 생성
+     * # MethodName : activeSetKey
+     **/
     private String activeSetKey(Long scheduleId) {
         return "queue:active:" + scheduleId;
     }
-    // 콘서트별 WAITING(대기중) ZSet의 key
+
+    /**
+     * # Method설명 : 일정ID로 WAITING(대기중) key 생성
+     * # MethodName : waitingSetKey
+     **/
     private String waitingSetKey(Long scheduleId) {
         return "queue:waiting:" + scheduleId;
     }
@@ -47,8 +60,8 @@ public class RedisQueueTokenRepository implements QueueTokenRepository {
      **/
     @Override
     public void save(QueueToken queueToken) {
-        redisTemplate.opsForValue().set(tokenInfoKey(queueToken.getToken()), queueToken);   // 토큰 정보 전체 저장
-        redisTemplate.opsForValue().set(userScheduleKey(queueToken.getUserId(), queueToken.getScheduleId()), queueToken.getToken());    // userId, scheduleId 조합으로 token(문자열) 저장
+        redisTemplate.opsForValue().set(tokenInfoKey(queueToken.getToken()), queueToken);   // queue:token:대기열 토큰
+        redisTemplate.opsForValue().set(userScheduleKey(queueToken.getUserId(), queueToken.getScheduleId()), queueToken.getToken());    // queue:user-schedule:대기열 토큰
 
         if (queueToken.getStatus() == QueueStatus.ACTIVE) { // 활성화 상태
             saveActiveToken(queueToken);    // 입장 가능한 상태면 ACTIVE ZSet에
@@ -58,33 +71,33 @@ public class RedisQueueTokenRepository implements QueueTokenRepository {
     }
 
     /**
-     * # Method설명 : 특정 사용자/콘서트 일정 기준으로 토큰 id 조회
+     * # Method설명 : userId+scheduleId 키로 대기열 토큰 조회
      * # MethodName : findTokenIdByUserIdAndScheduleId
      **/
     @Override
     public Optional<String> findTokenIdByUserIdAndScheduleId(Long userId, Long scheduleId) {
-        Object token = redisTemplate.opsForValue().get(userScheduleKey(userId, scheduleId));    // userScheduleKey로 Redis에서 tokenId 조회
+        Object token = redisTemplate.opsForValue().get(userScheduleKey(userId, scheduleId));    // userScheduleKey로 Redis에서 대기열토큰조회
         return token != null ? Optional.of(token.toString()) : Optional.empty();    // 값이 있으면 Optional로 감싸서 반환, 없으면 Optional.empty()
     }
 
     /**
-     * # Method설명 : 토큰 id로 토큰 전체 정보 조회
+     * # Method설명 : 대기열토큰(token)으로 토큰 전체 정보(QueueToken) 조회
      * # MethodName : findQueueTokenByTokenId
      **/
     @Override
-    public Optional<QueueToken> findQueueTokenByTokenId(String tokenId) {
-        Object tokenObj = redisTemplate.opsForValue().get(tokenInfoKey(tokenId));
+    public Optional<QueueToken> findQueueTokenByTokenId(String token) {
+        Object tokenObj = redisTemplate.opsForValue().get(tokenInfoKey(token));
         if (tokenObj == null) return Optional.empty();
 
-        if (tokenObj instanceof QueueToken token) {
-            return Optional.of(token);
+        if (tokenObj instanceof QueueToken queueToken) {
+            return Optional.of(queueToken);
         }
 
         if (tokenObj instanceof java.util.Map map) {
             ObjectMapper mapper = new ObjectMapper();
             mapper.registerModule(new JavaTimeModule());
-            QueueToken token = mapper.convertValue(map, QueueToken.class);
-            return Optional.of(token);
+            QueueToken queueToken = mapper.convertValue(map, QueueToken.class);
+            return Optional.of(queueToken);
         }
 
         return Optional.empty();
@@ -97,8 +110,8 @@ public class RedisQueueTokenRepository implements QueueTokenRepository {
     @Override
     public Optional<Integer> findWaitingPosition(QueueToken queueToken) {
         String waitingKey = waitingSetKey(queueToken.getScheduleId());  // 대기열 ZSet의 키
-        String userSchedule = userScheduleKey(queueToken.getUserId(), queueToken.getScheduleId());   // 대기열 ZSet에 저장된 값: userId와 scheduleId를 묶은 문자열(key)
-        Long rank = redisTemplate.opsForZSet().rank(waitingKey, userSchedule);  // ZSet에서 내 "랭크"를 가져옴 (0번부터 시작)
+        String userSchedule = userScheduleKey(queueToken.getUserId(), queueToken.getScheduleId());   // queue:user-schedule:대기열 토큰
+        Long rank = redisTemplate.opsForZSet().rank(waitingKey, userSchedule);  // 대기열에서 내 순번 조회 (0번부터 시작)
         return rank != null ? Optional.of(rank.intValue() + 1) : Optional.empty(); // 1-based 순번
     }
 
@@ -108,7 +121,7 @@ public class RedisQueueTokenRepository implements QueueTokenRepository {
      **/
     @Override
     public int countWaitingTokens(Long scheduleId) {
-        Long count = redisTemplate.opsForZSet().count( waitingSetKey(scheduleId), Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+        Long count = redisTemplate.opsForZSet().count(waitingSetKey(scheduleId), Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
         return count != null ? count.intValue() : 0;
     }
 
@@ -188,9 +201,10 @@ public class RedisQueueTokenRepository implements QueueTokenRepository {
     }
 
 
-
-
-    // WAITING(대기 중) 상태 토큰 저장용
+    /**
+     * # Method설명 : WAITING(대기 중) 상태 토큰 저장
+     * # MethodName : saveWaitingToken
+     **/
     private void saveWaitingToken(QueueToken queueToken) {
         String waitingKey = waitingSetKey(queueToken.getScheduleId());
         String userSchedule = userScheduleKey(queueToken.getUserId(), queueToken.getScheduleId());
@@ -207,7 +221,10 @@ public class RedisQueueTokenRepository implements QueueTokenRepository {
         redisTemplate.expire(userSchedule, Duration.ofHours(24));
     }
 
-    // ACTIVE(입장가능) 상태 토큰 저장용
+    /**
+     * # Method설명 : ACTIVE(입장가능) 상태 토큰 저장
+     * # MethodName : saveActiveToken
+     **/
     private void saveActiveToken(QueueToken queueToken) {
         String activeKey = activeSetKey(queueToken.getScheduleId());
         String userSchedule = userScheduleKey(queueToken.getUserId(), queueToken.getScheduleId());

--- a/src/main/java/kr/hhplus/be/server/infrastructure/persistence/reservation/SeatReservationJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/persistence/reservation/SeatReservationJpaRepository.java
@@ -57,6 +57,11 @@ public class SeatReservationJpaRepository implements SeatReservationRepository {
     }
 
     @Override
+    public Long findSeatIdById(Long reservationId) {
+        return seatReservationRepository.findSeatIdById(reservationId).orElse(0L);
+    }
+
+    @Override
     public void deleteAllForTest() {
         seatReservationRepository.deleteAll();
     }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/persistence/reservation/SpringDataSeatReservationJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/persistence/reservation/SpringDataSeatReservationJpaRepository.java
@@ -20,4 +20,7 @@ public interface SpringDataSeatReservationJpaRepository extends JpaRepository<Se
     Optional<SeatReservationEntity> findByReservationIdAndUser_UserId(Long reservationId, Long userId);
 
     List<SeatReservationEntity> findByStatusAndExpiredAtBefore(ReservationStatus status, LocalDateTime expiredAt);
+
+    @Query("SELECT sr.seat.seatId FROM SeatReservationEntity sr WHERE sr.reservationId = :reservationId")
+    Optional<Long> findSeatIdById(@Param("reservationId") Long reservationId);
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/persistence/user/SpringDataUserBalanceJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/persistence/user/SpringDataUserBalanceJpaRepository.java
@@ -16,9 +16,19 @@ public interface SpringDataUserBalanceJpaRepository extends JpaRepository<UserBa
      **/
     Optional<UserBalanceEntity> findTopByUser_UserIdOrderByBalanceHistoryIdDesc(Long userId);
 
-    // 가장 최근 내역을 "for update"로 select
+    /**
+     * # Method설명 : 가장 최근 내역 조회 - 비관적 락 적용
+     * # MethodName : findTopByUser_UserIdOrderByBalanceHistoryIdDescForUpdate
+     **/
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT ub FROM UserBalanceEntity ub WHERE ub.user.userId = :userId ORDER BY ub.balanceHistoryId DESC")
     Optional<UserBalanceEntity> findTopByUser_UserIdOrderByBalanceHistoryIdDescForUpdate(@Param("userId") Long userId);
+
+    /**
+     * # Method설명 : 사용자 현재 잔액 조회
+     * # MethodName : findCurrentBalanceByUserId
+     **/
+    @Query("SELECT ub.currentBalance FROM UserBalanceEntity ub WHERE ub.user.userId = :userId ORDER BY ub.balanceHistoryId DESC")
+    Optional<Long> findCurrentBalanceByUserId(@Param("userId") Long userId);
 
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/persistence/user/SpringDataUserBalanceJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/persistence/user/SpringDataUserBalanceJpaRepository.java
@@ -28,7 +28,9 @@ public interface SpringDataUserBalanceJpaRepository extends JpaRepository<UserBa
      * # Method설명 : 사용자 현재 잔액 조회
      * # MethodName : findCurrentBalanceByUserId
      **/
-    @Query("SELECT ub.currentBalance FROM UserBalanceEntity ub WHERE ub.user.userId = :userId ORDER BY ub.balanceHistoryId DESC")
+//    @Query("SELECT ub.currentBalance FROM UserBalanceEntity ub WHERE ub.user.userId = :userId ORDER BY ub.balanceHistoryId DESC ")
+//    Optional<Long> findCurrentBalanceByUserId(@Param("userId") Long userId);
+    @Query(value = "SELECT current_balance FROM user_balance_history WHERE user_id = :userId ORDER BY balance_history_id DESC LIMIT 1", nativeQuery = true)
     Optional<Long> findCurrentBalanceByUserId(@Param("userId") Long userId);
 
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/persistence/user/UserBalanceJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/persistence/user/UserBalanceJpaRepository.java
@@ -41,6 +41,11 @@ public class UserBalanceJpaRepository implements UserBalanceRepository {
         userBalanceRepository.deleteAll();
     }
 
+    @Override
+    public Long findCurrentBalanceByUserId(Long userId) {
+        return userBalanceRepository.findCurrentBalanceByUserId(userId).orElse(0L);
+    }
+
 
     private UserBalanceEntity toEntity(UserBalance domain) {
         // 1. id로 User, Seat 객체 조회

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,17 @@ spring:
   # 캐시 타입 - redis
   cache:
     type: redis
+    redis:
+      configs:
+        concert-schedules:
+          ttl: 3600000    # 1시간
+          max-idle-time: 0
+        concert-schedule:
+          ttl: 600000     # 10분
+          max-idle-time: 0
+        concert-seats:
+          ttl: 60000      # 1분
+          max-idle-time: 0
 
 ---
 spring.config.activate.on-profile: local, test

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,6 +27,9 @@ spring:
     redis:
       host: localhost
       port: 6379
+  # 캐시 타입 - redis
+  cache:
+    type: redis
 
 ---
 spring.config.activate.on-profile: local, test

--- a/src/test/java/kr/hhplus/be/server/application/payment/PaymentServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/payment/PaymentServiceTest.java
@@ -4,6 +4,7 @@ import kr.hhplus.be.server.common.exception.ApiException;
 import kr.hhplus.be.server.domain.concert.Seat;
 import kr.hhplus.be.server.domain.concert.SeatRepository;
 import kr.hhplus.be.server.domain.concert.SeatStatus;
+import kr.hhplus.be.server.domain.lock.DistributedLockRepository;
 import kr.hhplus.be.server.domain.payment.Payment;
 import kr.hhplus.be.server.domain.payment.PaymentRepository;
 import kr.hhplus.be.server.domain.payment.PaymentStatus;
@@ -11,66 +12,66 @@ import kr.hhplus.be.server.domain.queue.QueueTokenRepository;
 import kr.hhplus.be.server.domain.reservation.ReservationStatus;
 import kr.hhplus.be.server.domain.reservation.SeatReservation;
 import kr.hhplus.be.server.domain.reservation.SeatReservationRepository;
-import kr.hhplus.be.server.domain.user.*;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.domain.user.UserBalanceRepository;
+import kr.hhplus.be.server.domain.user.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 class PaymentServiceTest {
 
-    private PaymentRepository paymentRepository;
-    private SeatReservationRepository seatReservationRepository;
-    private UserRepository userRepository;
-    private UserBalanceRepository userBalanceRepository;
-    private SeatRepository seatRepository;
-    private QueueTokenRepository queueTokenRepository;
+    @Mock PaymentRepository paymentRepository;
+    @Mock SeatReservationRepository seatReservationRepository;
+    @Mock UserRepository userRepository;
+    @Mock UserBalanceRepository userBalanceRepository;
+    @Mock SeatRepository seatRepository;
+    @Mock QueueTokenRepository queueTokenRepository;
+    @Mock DistributedLockRepository distributedLockRepository;
 
-    private PaymentService paymentService;
 
+    @InjectMocks
+    PaymentService paymentService;
+
+    Long userId = 1L;
+    Long reservationId = 1L;
+    Long seatId = 1L;
+    Long scheduleId = 1L;
+    int price = 30000;
+    long currentBalance = 50000L;
+
+    User user;
+    Seat seat;
+    SeatReservation reservation;
     @BeforeEach
     void setUp() {
-        paymentRepository = mock(PaymentRepository.class);
-        seatReservationRepository = mock(SeatReservationRepository.class);
-        userRepository = mock(UserRepository.class);
-        userBalanceRepository = mock(UserBalanceRepository.class);
-        seatRepository = mock(SeatRepository.class);
-        queueTokenRepository = mock(QueueTokenRepository.class);
-
-        paymentService = new PaymentService(
-                paymentRepository,
-                seatReservationRepository,
-                userRepository,
-                userBalanceRepository,
-                seatRepository,
-                queueTokenRepository
-        );
+        user = new User(userId, "", "test@test.com", "pw", "사용자", null, null);
+        seat = new Seat(seatId, scheduleId, 1, price, SeatStatus.TEMP_RESERVED, LocalDateTime.now(), LocalDateTime.now());
+        reservation = new SeatReservation(reservationId, userId, seatId, ReservationStatus.TEMP_RESERVED, LocalDateTime.now().plusMinutes(5), LocalDateTime.now(), LocalDateTime.now());
     }
 
     @Test
     void 결제_정상_진행() {
         // given
-        Long userId = 1L;
-        Long reservationId = 100L;
-        Long seatId = 10L;
-        Long scheduleId = 5L;
-        int price = 30000;
-        long currentBalance = 50000L;
-
-        User user = new User(userId, "", "test@test.com", "pw", "사용자", null, null);
-        Seat seat = new Seat(seatId, scheduleId, 1, price, SeatStatus.TEMP_RESERVED, LocalDateTime.now(), LocalDateTime.now());
-        SeatReservation reservation = new SeatReservation(reservationId, userId, seatId, ReservationStatus.TEMP_RESERVED, LocalDateTime.now().plusMinutes(10), LocalDateTime.now(), LocalDateTime.now());
         Payment payment = Payment.create(userId, reservationId, price, PaymentStatus.SUCCESS);
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));    // 사용자 조회
-        when(seatReservationRepository.findByIdForUpdate(reservationId)).thenReturn(Optional.of(reservation));  // 예약 조회
-        when(seatRepository.findBySeatIdForUpdate(seatId)).thenReturn(Optional.of(seat));   // 좌석 조회
-        when(userBalanceRepository.findTopByUser_UserIdOrderByBalanceHistoryIdDescForUpdate(userId))    // 잔액 조회
-                .thenReturn(Optional.of(new UserBalance(null, userId, 0L, UserBalanceType.CHARGE, currentBalance, null, null)));
+        when(seatReservationRepository.findSeatIdById(reservationId)).thenReturn(seatId);   // 좌석id 조회
+        when(distributedLockRepository.tryLock(anyString(), anyString(), anyLong())).thenReturn(true);
+        when(seatReservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));  // 예약 조회
+        when(seatRepository.findById(seatId)).thenReturn(Optional.of(seat));   // 좌석 조회
+        when(userBalanceRepository.findCurrentBalanceByUserId(userId)).thenReturn(currentBalance); // 잔액 조회
         when(userBalanceRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
         when(paymentRepository.save(any())).thenReturn(payment);
         when(queueTokenRepository.findTokenIdByUserIdAndScheduleId(userId, scheduleId)).thenReturn(Optional.empty());
@@ -97,32 +98,27 @@ class PaymentServiceTest {
         when(userRepository.findById(1L)).thenReturn(Optional.empty());
 
         // then
-        assertThatThrownBy(() -> paymentService.payment(1L, 100L))
-                .isInstanceOf(ApiException.class)
-                .hasMessageContaining("사용자를 찾을 수 없습니다");
+        assertThatThrownBy(() -> paymentService.payment(userId, reservationId))
+                .isInstanceOf(ApiException.class);
     }
 
     @Test
     void 만료된_예약은_예외() {
         // given
-        Long userId = 1L;
-        Long reservationId = 100L;
-
         SeatReservation expiredReservation = new SeatReservation(
                 reservationId, userId, 10L,
                 ReservationStatus.TEMP_RESERVED,
                 LocalDateTime.now().minusMinutes(1),  // 만료
-                LocalDateTime.now().minusMinutes(10),
+                LocalDateTime.now().minusMinutes(6),
                 LocalDateTime.now()
         );
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(mock(User.class)));
-        when(seatReservationRepository.findByIdForUpdate(reservationId))
-                .thenReturn(Optional.of(expiredReservation));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(distributedLockRepository.tryLock(anyString(), anyString(), anyLong())).thenReturn(true);
+        when(seatReservationRepository.findById(reservationId)).thenReturn(Optional.of(expiredReservation));
 
         // then
         assertThatThrownBy(() -> paymentService.payment(userId, reservationId))
-                .isInstanceOf(ApiException.class)
-                .hasMessageContaining("결제할 수 없는 예약 정보");
+                .isInstanceOf(ApiException.class);
     }
 }

--- a/src/test/java/kr/hhplus/be/server/application/payment/PaymentServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/payment/PaymentServiceTest.java
@@ -24,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -68,7 +69,12 @@ class PaymentServiceTest {
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));    // 사용자 조회
         when(seatReservationRepository.findSeatIdById(reservationId)).thenReturn(seatId);   // 좌석id 조회
-        when(distributedLockRepository.tryLock(anyString(), anyString(), anyLong())).thenReturn(true);
+        when(distributedLockRepository.withMultiLock(anyList(), any(), anyLong(), anyInt(), anyLong()))
+                .thenAnswer(invocation -> {
+                    // 실제 람다 실행
+                    Supplier<?> supplier = invocation.getArgument(1);
+                    return supplier.get();
+                });
         when(seatReservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));  // 예약 조회
         when(seatRepository.findById(seatId)).thenReturn(Optional.of(seat));   // 좌석 조회
         when(userBalanceRepository.findCurrentBalanceByUserId(userId)).thenReturn(currentBalance); // 잔액 조회
@@ -114,7 +120,12 @@ class PaymentServiceTest {
         );
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(distributedLockRepository.tryLock(anyString(), anyString(), anyLong())).thenReturn(true);
+        when(distributedLockRepository.withMultiLock(anyList(), any(), anyLong(), anyInt(), anyLong()))
+                .thenAnswer(invocation -> {
+                    // 실제 람다 실행
+                    Supplier<?> supplier = invocation.getArgument(1);
+                    return supplier.get();
+                });
         when(seatReservationRepository.findById(reservationId)).thenReturn(Optional.of(expiredReservation));
 
         // then

--- a/src/test/java/kr/hhplus/be/server/application/reservation/ReserveSeatServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/reservation/ReserveSeatServiceTest.java
@@ -40,6 +40,8 @@ class ReserveSeatServiceTest {
     UserRepository userRepository;
     @Mock
     QueueTokenRepository queueTokenRepository;
+    @Mock
+    DistributedLockRepository distributedLockRepository;
 
     @BeforeEach
     void setUp() {
@@ -70,8 +72,13 @@ class ReserveSeatServiceTest {
         when(queueToken.isExpired()).thenReturn(false);
         when(queueToken.isActive()).thenReturn(true);
 
-        // Seat 조회 (비관적락)
-        when(seatRepository.findByConcertSchedule_ScheduleIdAndSeatNumberForUpdate(100L, seatNumber)).thenReturn(Optional.of(seat));
+        // Lock 획득 성공
+        when(distributedLockRepository.tryLock(anyString(), anyString(), anyLong())).thenReturn(true);
+
+        // Seat 조회 및 임시예약 가능
+        when(seatRepository.findByConcertSchedule_ScheduleIdAndSeatNumber(100L, seatNumber)).thenReturn(Optional.of(seat));
+        // when(seatRepository.findByConcertSchedule_ScheduleIdAndSeatNumberForUpdate(100L, seatNumber)).thenReturn(Optional.of(seat)); // Seat 조회 (비관적락)
+
         when(seat.getStatus()).thenReturn(SeatStatus.TEMP_RESERVED);
         when(seat.isExpired(anyInt())).thenReturn(false);
         when(seat.isAvailable(anyInt())).thenReturn(true);

--- a/src/test/java/kr/hhplus/be/server/integration/UserBalanceServiceConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/integration/UserBalanceServiceConcurrencyTest.java
@@ -120,14 +120,11 @@ public class UserBalanceServiceConcurrencyTest {
         latch.await();
 
         // then
-        // 한 번만 성공, 나머지는 실패
+        // 전체 성공
         long successCount = results.stream().filter(r -> r).count();
-        long failCount = results.stream().filter(r -> !r).count();
+        assertThat(successCount).isEqualTo(threadCount);
 
-        assertThat(successCount).isEqualTo(1);
-        assertThat(failCount).isEqualTo(threadCount - successCount);
-
-        // 최종 잔액은 확인
+        // 최종 잔액 확인
         UserBalance balance = userService.getCurrentBalance(userId);
         assertThat(balance.getCurrentBalance()).isEqualTo(10000L * (successCount+1));
     }


### PR DESCRIPTION
### **커밋 설명**
- Redis 기반 분산락 적용 — #37 
- 분산락 적용 단위테스트 및 통합테스트 리팩토링 — #38 

---
### **리뷰 받고 싶은 내용(질문)**

**리뷰 포인트 1**
- 커밋 : Redis 기반 분산락 적용 — #37 
- 내용 : 
분산락 적용 시, 여러 개의 lock-key가 필요한 경우 순차적으로 lock을 획득하는 방식으로 구현했습니다.
이 접근 방식이 적절한지, 혹시 개선할 여지가 있다면 피드백 부탁드립니다!

[ 🔗 관련 코드 : PaymentService ](https://github.com/y-00jin/hhplus-server-concert/blob/week6/src/main/java/kr/hhplus/be/server/application/payment/PaymentService.java)


---

**리뷰 포인트 2**
- 내용 : 
5주차 피드백 중 **"클라이언트에서 예외를 구분하여 처리할수있게 커스텀 예외를 추가하면 좋을것같습니다."** 는 의견이 있었는데 이에 대해 궁금한 점이 있어 질문드립니다. 

[🔗 5주차 PR 피드백](https://github.com/y-00jin/hhplus-server-concert/pull/35#issuecomment-2993963193) 

현재 프로젝트에서는 아래와 같은 구조로 커스텀 예외 처리를 적용하고 있습니다:

- `ApiException`을 직접 발생시킴
- `ErrorCode`로 에러 유형 관리
- `ErrorResponse`, `GlobalExceptionHandler`로 공통 에러 응답 처리

```java
throw new ApiException(ErrorCode.에러코드, "메시지");
```

**🔗 관련 클래스**

![image](https://github.com/user-attachments/assets/b58fb118-a56b-4b6f-8e4b-72d253e23b8b)

- [ApiException](https://github.com/y-00jin/hhplus-server-concert/blob/main/src/main/java/kr/hhplus/be/server/common/exception/ApiException.java)
- [ErrorCode](https://github.com/y-00jin/hhplus-server-concert/blob/main/src/main/java/kr/hhplus/be/server/common/exception/ErrorCode.java)
- [ErrorResponse](https://github.com/y-00jin/hhplus-server-concert/blob/main/src/main/java/kr/hhplus/be/server/common/exception/ErrorResponse.java)
- [GlobalExceptionHandler](https://github.com/y-00jin/hhplus-server-concert/blob/main/src/main/java/kr/hhplus/be/server/common/exception/GlobalExceptionHandler.java)


혹시 멘토님께서 말씀하신 "클라이언트에서 예외 구분"이라는 게 위 방식 외에 추가적으로 고려해야 할 부분이 있는지,
또는 더 구체적인 요구사항(예: 특정 상황별 세분화된 에러코드 등)이 있는 건지 궁금합니다.

피드백 주시면 더 반영해보겠습니다! 감사합니다 :)
